### PR TITLE
Patch to use $(MAKE) instead of make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ archive:
 archive-check: archive
 	@ rm -rf $(THIS)
 	@ tar xvfz $(DATE).tar.gz
-	@ make -C $(THIS) -j
+	@ $(MAKE) -C $(THIS) -j
 	@ rm -rf $(THIS) $(DATE).tar.gz
 
 # -------------------------------------------------------------------------
@@ -64,7 +64,7 @@ release:
 	    echo "Now making a release..." ; \
 	  fi
 # Create an archive and make sure that it compiles.
-	make archive-check
+	$(MAKE) archive-check
 # Create a git tag.
 	@ git tag -a $(DATE) -m "Release $(DATE)."
 # Upload. (This automatically makes a .tar.gz archive available on github.)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: all clean install uninstall
 all clean install uninstall:
-	@ make -C src $@
+	@ $(MAKE) -C src $@


### PR DESCRIPTION
Some systems (such as OpenBSD) use BSD make by default, and package
GNU make separately as `gmake`. The current Makefile (and GNUMakefile)
have recursive calls to make with an explicit `make` command (rather
than `$(MAKE)`), which causes errors on systems that default to BSD
make.

Thank you for this library! I'm very much enjoying going through the
Separation Logic Foundations book :)