### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/LibEqual.v
+++ b/src/LibEqual.v
@@ -863,7 +863,7 @@ Proof using. introv E. dependent rewrite E. simple~. constructor. Qed.
 (* ********************************************************************** *)
 (** * John Major's equality *)
 
-Require Import Coq.Logic.JMeq.
+From Stdlib.Logic Require Import JMeq.
 
 (** The module above defines John Major's equality:
 

--- a/src/LibInt.v
+++ b/src/LibInt.v
@@ -4,7 +4,7 @@
 **************************************************************************)
 
 Set Implicit Arguments.
-Require Export Coq.ZArith.ZArith.
+From Stdlib Require Export ZArith.
 From TLC Require Import LibTactics LibLogic LibReflect LibRelation.
 Export LibTacticsCompatibility.
 From TLC Require Export LibNat.

--- a/src/LibIntTactics.v
+++ b/src/LibIntTactics.v
@@ -15,7 +15,7 @@
 
 
 Set Implicit Arguments.
-Require Import Coq.micromega.Psatz.
+From Stdlib Require Import Psatz.
 From TLC Require Import LibTactics.
 From TLC Require Export LibInt.
 

--- a/src/LibNat.v
+++ b/src/LibNat.v
@@ -4,7 +4,7 @@
 **************************************************************************)
 
 Set Implicit Arguments.
-Require Export Coq.Arith.Arith Coq.micromega.Lia.
+From Stdlib Require Export Arith Lia.
 From TLC Require Import LibTactics LibReflect LibBool LibOperation LibRelation LibOrder.
 From TLC Require Export LibOrder.
 Global Close Scope positive_scope.

--- a/src/LibTactics.v
+++ b/src/LibTactics.v
@@ -370,7 +370,7 @@ Ltac fast_rm_inside E :=
     Note: the tactic [number_to_nat] is extended in [LibInt] to
     take into account the [Z] type. *)
 
-Require Coq.Numbers.BinNums Coq.ZArith.BinInt.
+From Stdlib Require BinNums BinInt.
 
 Definition ltac_int_to_nat (x:BinInt.Z) : nat :=
   match x with
@@ -2564,7 +2564,7 @@ Tactic Notation "subst_eq" constr(E) :=
 (* ---------------------------------------------------------------------- *)
 (** ** Tactics to Work with Proof Irrelevance *)
 
-Require Import Coq.Logic.ProofIrrelevance.
+From Stdlib.Logic Require Import ProofIrrelevance.
 
 (** [pi_rewrite E] replaces [E] of type [Prop] with a fresh
     unification variable, and is thus a practical way to
@@ -3220,7 +3220,7 @@ Tactic Notation "cases_if'" :=
     [inductions E gen X1 .. XN] is a shorthand for
     [dependent induction E generalizing X1 .. XN]. *)
 
-Require Import Coq.Program.Equality.
+From Stdlib.Program Require Import Equality.
 
 Ltac inductions_post :=
   unfold eq' in *.
@@ -3297,8 +3297,8 @@ Tactic Notation "induction_wf" ident(IH) ":" constr(E) ident(X) :=
     judgment that includes a counter for the maximal height
     (see LibTacticsDemos for an example) *)
 
-Require Import Coq.Arith.Compare_dec.
-Require Import Coq.micromega.Lia.
+From Stdlib.Arith Require Import Compare_dec.
+From Stdlib.micromega Require Import Lia.
 
 Lemma induct_height_max2 : forall n1 n2 : nat,
   exists n, n1 < n /\ n2 < n.

--- a/src/LibTacticsDemos.v
+++ b/src/LibTacticsDemos.v
@@ -5,7 +5,7 @@
 
 Set Implicit Arguments.
 From TLC Require Import LibTactics.
-Require Import Coq.micromega.Lia.
+From Stdlib.micromega Require Import Lia.
 
 
 (* ********************************************************************** *)


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.